### PR TITLE
fix(custom-commands): align response content max length to 500 chars

### DIFF
--- a/src/app/dialogs/custom-command-editor-dialog/custom-command-editor-dialog.component.ts
+++ b/src/app/dialogs/custom-command-editor-dialog/custom-command-editor-dialog.component.ts
@@ -234,7 +234,7 @@ export class CustomCommandEditorDialogComponent {
   private constructResponseForm(response: CommandResponse) {
     return this.formBuilder.group({
       type: [response.type, [Validators.required]],
-      content: [response.content, [Validators.required, Validators.maxLength(300)]],
+      content: [response.content, [Validators.required, Validators.maxLength(500)]],
       auxiliaryContent: [response.auxiliaryContent],
       sendAsReply: [response.sendAsReply],
     });


### PR DESCRIPTION
## Summary

- Editor dialog validated response content with `maxLength(300)` while the standalone response form component used `maxLength(500)`
- Users could not save custom command responses between 301–500 characters
- Fix: align dialog validator to `maxLength(500)`

## Test plan

- [ ] Edit a custom command and set response content to >300 and ≤500 characters — save should now succeed
- [ ] Verify content >500 characters is still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)